### PR TITLE
Add string properties for IfStartsWith and IfNotStartsWith

### DIFF
--- a/src/Throw.csproj
+++ b/src/Throw.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <PackageId>Throw</PackageId>
-    <Version>1.1.2</Version>
+    <Version>1.1.3</Version>
     <Authors>Amichai Mantinband</Authors>
     <PackageIcon>icon-square.png</PackageIcon>
     <PackageTags>argument,guard,clause,exception,contract,assert,assertions,validation</PackageTags>

--- a/src/ValidatableExtensions/ValidatableExtensions.StringProperties.cs
+++ b/src/ValidatableExtensions/ValidatableExtensions.StringProperties.cs
@@ -184,4 +184,34 @@ public static partial class ValidatableExtensions
 
         return ref validatable;
     }
+
+    /// <summary>
+    /// Throws an exception if the string returned from the given <paramref name="func"/> start with <paramref name="str"/>.
+    /// </summary>
+    /// <remarks>
+    /// The default exception thrown is an <see cref="ArgumentException"/>.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref readonly Validatable<TValue> IfStartsWith<TValue>(this in Validatable<TValue> validatable, Func<TValue, string> func, string str, [CallerArgumentExpression("func")] string? funcName = null)
+        where TValue : notnull
+    {
+        Validator.ThrowIfStartsWith(func(validatable.Value), $"{validatable.ParamName}: {funcName}", validatable.ExceptionCustomizations, str);
+
+        return ref validatable;
+    }
+
+    /// <summary>
+    /// Throws an exception if the string returned from the given <paramref name="func"/> does not start with <paramref name="str"/>.
+    /// </summary>
+    /// <remarks>
+    /// The default exception thrown is an <see cref="ArgumentException"/>.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref readonly Validatable<TValue> IfNotStartsWith<TValue>(this in Validatable<TValue> validatable, Func<TValue, string> func, string str, [CallerArgumentExpression("func")] string? funcName = null)
+        where TValue : notnull
+    {
+        Validator.ThrowIfNotStartsWith(func(validatable.Value), $"{validatable.ParamName}: {funcName}", validatable.ExceptionCustomizations, str);
+
+        return ref validatable;
+    }
 }

--- a/src/ValidatableExtensions/ValidatableExtensions.StringProperties.cs
+++ b/src/ValidatableExtensions/ValidatableExtensions.StringProperties.cs
@@ -216,7 +216,7 @@ public static partial class ValidatableExtensions
     }
 
     /// <summary>
-    /// Throws an exception if the string returned from the given <paramref name="func"/> start with <paramref name="str"/>.
+    /// Throws an exception if the string returned from the given <paramref name="func"/> starts with <paramref name="str"/>.
     /// </summary>
     /// <remarks>
     /// The default exception thrown is an <see cref="ArgumentException"/>.

--- a/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
+++ b/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
@@ -174,7 +174,7 @@ public static partial class ValidatableExtensions
     }
 
     /// <summary>
-    /// Throws an exception if the string start with <paramref name="str"/>.
+    /// Throws an exception if the string starts with <paramref name="str"/>.
     /// </summary>
     /// <remarks>
     /// The default exception thrown is an <see cref="ArgumentException"/>.

--- a/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
+++ b/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
@@ -144,4 +144,32 @@ public static partial class ValidatableExtensions
 
         return ref validatable;
     }
+
+    /// <summary>
+    /// Throws an exception if the string start with <paramref name="str"/>.
+    /// </summary>
+    /// <remarks>
+    /// The default exception thrown is an <see cref="ArgumentException"/>.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref readonly Validatable<string> IfStartsWith(this in Validatable<string> validatable, string str)
+    {
+        Validator.ThrowIfStartsWith(validatable.Value, validatable.ParamName, validatable.ExceptionCustomizations, str);
+
+        return ref validatable;
+    }
+
+    /// <summary>
+    /// Throws an exception if the string does not start with <paramref name="str"/>.
+    /// </summary>
+    /// <remarks>
+    /// The default exception thrown is an <see cref="ArgumentException"/>.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref readonly Validatable<string> IfNotStartsWith(this in Validatable<string> validatable, string str)
+    {
+        Validator.ThrowIfNotStartsWith(validatable.Value, validatable.ParamName, validatable.ExceptionCustomizations, str);
+
+        return ref validatable;
+    }
 }

--- a/src/Validators/Validator.Strings.cs
+++ b/src/Validators/Validator.Strings.cs
@@ -109,4 +109,22 @@ internal static partial class Validator
             ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String length should be equal to {length}.");
         }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfStartsWith(string value, string paramName, ExceptionCustomizations? exceptionCustomizations, string str)
+    {
+        if (value.StartsWith(str))
+        {
+            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should not start with '{str}'.");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfNotStartsWith(string value, string paramName, ExceptionCustomizations? exceptionCustomizations, string str)
+    {
+        if (!value.StartsWith(str))
+        {
+            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should start with '{str}'.");
+        }
+    }
 }

--- a/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringPropertiesTests.cs
+++ b/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringPropertiesTests.cs
@@ -408,4 +408,61 @@ public class StringPropertiesTests
         // Assert
         action.Should().NotThrow();
     }
+
+    [TestMethod]
+    public void ThrowIfPropertyStartsWith_WhenPropertyNotStartsWith_ShouldNotThrow()
+    {
+        // Arrange
+        var person = new { Name = "John" };
+
+        // Act
+        Action action = () => person.Throw().IfStartsWith(p => p.Name, "hh");
+
+        // Assert
+        action.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void ThrowIfPropertyStartsWith_WhenPropertyStartsWith_ShouldThrow()
+    {
+        // Arrange
+        var person = new { Name = "John" };
+
+        // Act
+        Action action = () => person.Throw().IfStartsWith(p => p.Name, "Jo");
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentException>()
+            .WithMessage($"String should not start with 'Jo'. (Parameter '{nameof(person)}: p => p.Name')");
+    }
+
+    [TestMethod]
+    public void ThrowIfPropertyNotStartsWith_WhenPropertyNotStartsWith_ShouldThrow()
+    {
+        // Arrange
+        var person = new { Name = "John" };
+
+        // Act
+        Action action = () => person.Throw().IfNotStartsWith(p => p.Name, "hn");
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentException>()
+            .WithMessage($"String should start with 'hn'. (Parameter '{nameof(person)}: p => p.Name')");
+
+    }
+
+    [TestMethod]
+    public void ThrowIfPropertyNotStartsWith_WhenPropertyStartsWith_ShouldNotThrow()
+    {
+        // Arrange
+        var person = new { Name = "John" };
+
+        // Act
+        Action action = () => person.Throw().IfNotStartsWith(p => p.Name, "Jo");
+
+        // Assert
+        action.Should().NotThrow();
+    }
 }

--- a/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
+++ b/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
@@ -310,4 +310,60 @@ public class StringsTests
         // Assert
         action.Should().NotThrow();
     }
+
+    [TestMethod]
+    public void ThrowIfStartsWith_WhenNotStartsWith_ShouldNotThrow()
+    {
+        // Arrange
+        string name = "John";
+
+        // Act
+        Action action = () => name.Throw().IfStartsWith("hn");
+
+        // Assert
+        action.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void ThrowIfStartsWith_WhenStartsWith_ShouldThrow()
+    {
+        // Arrange
+        string name = "John";
+        // Act
+        Action action = () => name.Throw().IfStartsWith("Jo");
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentException>()
+            .WithMessage($"String should not Start with 'Jo'. (Parameter '{nameof(name)}')");
+    }
+
+    [TestMethod]
+    public void ThrowIfNotStartsWith_WhenNotStartsWith_ShouldThrow()
+    {
+        // Arrange
+        string name = "John";
+
+        // Act
+        Action action = () => name.Throw().IfNotStartsWith("hn");
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentException>()
+            .WithMessage($"String should Start with 'hn'. (Parameter '{nameof(name)}')");
+
+    }
+
+    [TestMethod]
+    public void ThrowIfNotStartsWith_WhenStartsWith_ShouldNotThrow()
+    {
+        // Arrange
+        string name = "John";
+
+        // Act
+        Action action = () => name.Throw().IfNotStartsWith("Jo");
+
+        // Assert
+        action.Should().NotThrow();
+    }
 }

--- a/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
+++ b/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
@@ -335,7 +335,7 @@ public class StringsTests
         // Assert
         action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"String should not Start with 'Jo'. (Parameter '{nameof(name)}')");
+            .WithMessage($"String should not start with 'Jo'. (Parameter '{nameof(name)}')");
     }
 
     [TestMethod]
@@ -350,7 +350,7 @@ public class StringsTests
         // Assert
         action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"String should Start with 'hn'. (Parameter '{nameof(name)}')");
+            .WithMessage($"String should start with 'hn'. (Parameter '{nameof(name)}')");
 
     }
 


### PR DESCRIPTION
@mantinband Completed with Test

I updated the version in Throw.csproj from 1.1.2 to 1.1.3
I suggest this should be merged after Issue #22 (IfEndsWith) since they are similar I think they should be bundled together in a new build (1.1.3)