### PR TITLE
feat: Add option to pass StringComparison to string .IfEquals() (WIP)

### DIFF
--- a/src/ValidatableExtensions/ValidatableExtensions.StringProperties.cs
+++ b/src/ValidatableExtensions/ValidatableExtensions.StringProperties.cs
@@ -167,7 +167,7 @@ public static partial class ValidatableExtensions
     public static ref readonly Validatable<TValue> IfEqualsIgnoreCase<TValue>(this in Validatable<TValue> validatable, Func<TValue, string> func, string otherString, [CallerArgumentExpression("func")] string? funcName = null)
         where TValue : notnull
     {
-        Validator.ThrowIfEqualsIgnoreCase(func(validatable.Value), $"{validatable.ParamName}: {funcName}", validatable.ExceptionCustomizations, otherString);
+        Validator.ThrowIfEquals(func(validatable.Value), $"{validatable.ParamName}: {funcName}", validatable.ExceptionCustomizations, otherString, StringComparison.OrdinalIgnoreCase);
 
         return ref validatable;
     }

--- a/src/ValidatableExtensions/ValidatableExtensions.StringProperties.cs
+++ b/src/ValidatableExtensions/ValidatableExtensions.StringProperties.cs
@@ -96,16 +96,32 @@ public static partial class ValidatableExtensions
     }
 
     /// <summary>
-    /// Throws an exception if the string returned from the given <paramref name="func"/> equals the given <paramref name="otherString"/> (case sensitive).
+    /// Throws an exception if the string returned from the given <paramref name="func"/> equals the given <paramref name="otherString"/>.
     /// </summary>
     /// <remarks>
+    /// The <see cref="StringComparison"/> used is <see cref="StringComparison.Ordinal"/>.
     /// The default exception thrown is an <see cref="ArgumentException"/>.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref readonly Validatable<TValue> IfEquals<TValue>(this in Validatable<TValue> validatable, Func<TValue, string> func, string otherString, [CallerArgumentExpression("func")] string? funcName = null)
         where TValue : notnull
     {
-        Validator.ThrowIfEquals(func(validatable.Value), $"{validatable.ParamName}: {funcName}", validatable.ExceptionCustomizations, otherString);
+        Validator.ThrowIfEquals(func(validatable.Value), $"{validatable.ParamName}: {funcName}", validatable.ExceptionCustomizations, otherString, StringComparison.Ordinal);
+
+        return ref validatable;
+    }
+
+    /// <summary>
+    /// Throws an exception if the string returned from the given <paramref name="func"/> equals the given <paramref name="otherString"/> using the given <paramref name="comparisonType"/>.
+    /// </summary>
+    /// <remarks>
+    /// The default exception thrown is an <see cref="ArgumentException"/>.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref readonly Validatable<TValue> IfEquals<TValue>(this in Validatable<TValue> validatable, Func<TValue, string> func, string otherString, StringComparison comparisonType, [CallerArgumentExpression("func")] string? funcName = null)
+        where TValue : notnull
+    {
+        Validator.ThrowIfEquals(func(validatable.Value), $"{validatable.ParamName}: {funcName}", validatable.ExceptionCustomizations, otherString, comparisonType);
 
         return ref validatable;
     }

--- a/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
+++ b/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
@@ -128,7 +128,7 @@ public static partial class ValidatableExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref readonly Validatable<string> IfEqualsIgnoreCase(this in Validatable<string> validatable, string otherString)
     {
-        Validator.ThrowIfEqualsIgnoreCase(validatable.Value, validatable.ParamName, validatable.ExceptionCustomizations, otherString);
+        Validator.ThrowIfEquals(validatable.Value, validatable.ParamName, validatable.ExceptionCustomizations, otherString, StringComparison.OrdinalIgnoreCase);
 
         return ref validatable;
     }

--- a/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
+++ b/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
@@ -62,15 +62,30 @@ public static partial class ValidatableExtensions
     }
 
     /// <summary>
-    /// Throws an exception if the string equals the given <paramref name="otherString"/> (case sensitive).
+    /// Throws an exception if the string equals the given <paramref name="otherString"/>.
     /// </summary>
     /// <remarks>
+    /// The <see cref="StringComparison"/> used is <see cref="StringComparison.Ordinal"/>.
     /// The default exception thrown is an <see cref="ArgumentException"/>.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref readonly Validatable<string> IfEquals(this in Validatable<string> validatable, string otherString)
     {
-        Validator.ThrowIfEquals(validatable.Value, validatable.ParamName, validatable.ExceptionCustomizations, otherString);
+        Validator.ThrowIfEquals(validatable.Value, validatable.ParamName, validatable.ExceptionCustomizations, otherString, StringComparison.Ordinal);
+
+        return ref validatable;
+    }
+
+    /// <summary>
+    /// Throws an exception if the string equals the given <paramref name="otherString"/> using the given <paramref name="comparisonType"/>.
+    /// </summary>
+    /// <remarks>
+    /// The default exception thrown is an <see cref="ArgumentException"/>.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref readonly Validatable<string> IfEquals(this in Validatable<string> validatable, string otherString, StringComparison comparisonType)
+    {
+        Validator.ThrowIfEquals(validatable.Value, validatable.ParamName, validatable.ExceptionCustomizations, otherString, comparisonType);
 
         return ref validatable;
     }

--- a/src/Validators/Validator.Strings.cs
+++ b/src/Validators/Validator.Strings.cs
@@ -66,11 +66,11 @@ internal static partial class Validator
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void ThrowIfEquals(string value, string paramName, ExceptionCustomizations? exceptionCustomizations, string otherString)
+    internal static void ThrowIfEquals(string value, string paramName, ExceptionCustomizations? exceptionCustomizations, string otherString, StringComparison comparisonType)
     {
-        if (string.Equals(value, otherString, StringComparison.Ordinal))
+        if (string.Equals(value, otherString, comparisonType))
         {
-            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should not be equal to '{otherString}'.");
+            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should not be equal to '{otherString}' (comparison type: '{comparisonType}').");
         }
     }
 

--- a/src/Validators/Validator.Strings.cs
+++ b/src/Validators/Validator.Strings.cs
@@ -57,15 +57,6 @@ internal static partial class Validator
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void ThrowIfEqualsIgnoreCase(string value, string paramName, ExceptionCustomizations? exceptionCustomizations, string otherString)
-    {
-        if (string.Equals(value, otherString, StringComparison.OrdinalIgnoreCase))
-        {
-            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should not be equal to '{otherString}' (case insensitive).");
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void ThrowIfEquals(string value, string paramName, ExceptionCustomizations? exceptionCustomizations, string otherString, StringComparison comparisonType)
     {
         if (string.Equals(value, otherString, comparisonType))

--- a/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringPropertiesTests.cs
+++ b/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringPropertiesTests.cs
@@ -353,7 +353,7 @@ public class StringPropertiesTests
 
         // Assert
         action.Should().ThrowExactly<ArgumentException>()
-            .WithMessage($"String should not be equal to 'Amichai' (case insensitive). (Parameter '{nameof(person)}: p => p.Name')");
+            .WithMessage($"String should not be equal to 'Amichai' (comparison type: '{StringComparison.OrdinalIgnoreCase}'). (Parameter '{nameof(person)}: p => p.Name')");
     }
 
     [TestMethod]
@@ -367,7 +367,7 @@ public class StringPropertiesTests
 
         // Assert
         action.Should().ThrowExactly<ArgumentException>()
-            .WithMessage($"String should not be equal to 'Amichai' (case insensitive). (Parameter '{nameof(person)}: p => p.Name')");
+            .WithMessage($"String should not be equal to 'Amichai' (comparison type: '{StringComparison.OrdinalIgnoreCase}'). (Parameter '{nameof(person)}: p => p.Name')");
     }
 
     [TestMethod]

--- a/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringPropertiesTests.cs
+++ b/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringPropertiesTests.cs
@@ -231,7 +231,7 @@ public class StringPropertiesTests
 
         // Assert
         action.Should().ThrowExactly<ArgumentException>()
-            .WithMessage($"String should not be equal to 'Amichai'. (Parameter '{nameof(person)}: p => p.Name')");
+            .WithMessage($"String should not be equal to 'Amichai' (comparison type: '{StringComparison.Ordinal}'). (Parameter '{nameof(person)}: p => p.Name')");
     }
 
     [TestMethod]
@@ -242,6 +242,40 @@ public class StringPropertiesTests
 
         // Act
         Action action = () => person.Throw().IfEquals(p => p.Name, "Amichai2");
+
+        // Assert
+        action.Should().NotThrow();
+    }
+
+    [DataTestMethod]
+    [DataRow("value", "VALUE", StringComparison.OrdinalIgnoreCase)]
+    [DataRow("\u0061\u030a", "\u00e5", StringComparison.InvariantCulture)]
+    [DataRow("AA", "A\u0000\u0000\u0000a", StringComparison.InvariantCultureIgnoreCase)]
+    public void ThrowIfPropertyEquals_WhenPropertyEqualsUsingCustomComparisonType_ShouldThrow(string value, string otherValue, StringComparison comparisonType)
+    {
+        // Arrange
+        var person = new { Name = value };
+
+        // Act
+        Action action = () => person.Throw().IfEquals(p => p.Name, otherValue, comparisonType);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentException>()
+            .WithMessage($"String should not be equal to '{otherValue}' (comparison type: '{comparisonType}'). (Parameter '{nameof(person)}: p => p.Name')");
+    }
+
+    [DataTestMethod]
+    [DataRow("value", "different value", StringComparison.OrdinalIgnoreCase)]
+    [DataRow("\u0061\u030a", "different value", StringComparison.InvariantCulture)]
+    [DataRow("AA", "different value", StringComparison.InvariantCultureIgnoreCase)]
+    public void ThrowIfPropertyEquals_WhenPropertyNotEqualsUsingCustomComparisonType_ShouldNotThrow(string value, string otherValue, StringComparison comparisonType)
+    {
+        // Arrange
+        var person = new { Name = value };
+
+        // Act
+        Action action = () => person.Throw().IfEquals(p => p.Name, otherValue, comparisonType);
 
         // Assert
         action.Should().NotThrow();

--- a/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
+++ b/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
@@ -183,7 +183,7 @@ public class StringsTests
         // Assert
         action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"String should not be equal to 'value' (case insensitive). (Parameter '{nameof(value)}')");
+            .WithMessage($"String should not be equal to 'value' (comparison type: '{StringComparison.OrdinalIgnoreCase}'). (Parameter '{nameof(value)}')");
     }
 
     [TestMethod]
@@ -198,7 +198,7 @@ public class StringsTests
         // Assert
         action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"String should not be equal to 'VALUE' (case insensitive). (Parameter '{nameof(value)}')");
+            .WithMessage($"String should not be equal to 'VALUE' (comparison type: '{StringComparison.OrdinalIgnoreCase}'). (Parameter '{nameof(value)}')");
     }
 
     [TestMethod]

--- a/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
+++ b/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
@@ -127,7 +127,7 @@ public class StringsTests
         // Assert
         action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"String should not be equal to 'value'. (Parameter '{nameof(value)}')");
+            .WithMessage($"String should not be equal to 'value' (comparison type: '{StringComparison.Ordinal}'). (Parameter '{nameof(value)}')");
     }
 
     [TestMethod]
@@ -138,6 +138,34 @@ public class StringsTests
 
         // Act
         Action action = () => value.Throw().IfEquals("VALUE");
+
+        // Assert
+        action.Should().NotThrow();
+    }
+
+    [DataTestMethod]
+    [DataRow("value", "VALUE", StringComparison.OrdinalIgnoreCase)]
+    [DataRow("\u0061\u030a", "\u00e5", StringComparison.InvariantCulture)]
+    [DataRow("AA", "A\u0000\u0000\u0000a", StringComparison.InvariantCultureIgnoreCase)]
+    public void ThrowIfEquals_WhenEqualsUsingCustomComparisonType_ShouldThrow(string value, string otherValue, StringComparison comparisonType)
+    {
+        // Act
+        Action action = () => value.Throw().IfEquals(otherValue, comparisonType);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentException>()
+            .WithMessage($"String should not be equal to '{otherValue}' (comparison type: '{comparisonType}'). (Parameter '{nameof(value)}')");
+    }
+
+    [DataTestMethod]
+    [DataRow("value", "different value", StringComparison.OrdinalIgnoreCase)]
+    [DataRow("\u0061\u030a", "different value", StringComparison.InvariantCulture)]
+    [DataRow("AA", "different value", StringComparison.InvariantCultureIgnoreCase)]
+    public void ThrowIfEquals_WhenNotEqualsUsingCustomComparisonType_ShouldNotThrow(string value, string otherValue, StringComparison comparisonType)
+    {
+        // Act
+        Action action = () => value.Throw().IfEquals(otherValue, comparisonType);
 
         // Assert
         action.Should().NotThrow();


### PR DESCRIPTION
## Feature description
You can now pass StringComparison enum values as a param to IfEquals method. 

## Solution description
I've overloaded the IfEquals method and I've made some changes to the ThrowIsEquals function to return a modified error message when an exception is thrown. 

Because of this, I've had to make changes to two tests cases where I've modified the exception message accordingly. 

Let me know if this works for you. 

## WIP
I was trying to add test cases for all the conditions of StringComparison, however, I ran into some trouble trying to get a certain test case to pass. Please help me out here.