### PR TITLE
feat: Add IfContains and IfNotContains extension methods for strings

### DIFF
--- a/src/ValidatableExtensions/ValidatableExtensions.StringProperties.cs
+++ b/src/ValidatableExtensions/ValidatableExtensions.StringProperties.cs
@@ -261,4 +261,36 @@ public static partial class ValidatableExtensions
 
         return ref validatable;
     }
+
+    /// <summary>
+    /// Throws an exception if the string returned from the given <paramref name="func"/> contains the given <paramref name="otherString"/>.
+    /// Default <paramref name="comparisonType"/> is <see cref="StringComparison.Ordinal"/>.
+    /// </summary>
+    /// <remarks>
+    /// The default exception thrown is an <see cref="ArgumentException"/>.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref readonly Validatable<TValue> IfContains<TValue>(this in Validatable<TValue> validatable, Func<TValue, string> func, string otherString, StringComparison comparisonType = StringComparison.Ordinal, [CallerArgumentExpression("func")] string? funcName = null)
+        where TValue : notnull
+    {
+        Validator.ThrowIfContains(func(validatable.Value), $"{validatable.ParamName}: {funcName}", validatable.ExceptionCustomizations, otherString, comparisonType);
+
+        return ref validatable;
+    }
+
+    /// <summary>
+    /// Throws an exception if the string returned from the given <paramref name="func"/> does not contain the given <paramref name="otherString"/>.
+    /// Default <paramref name="comparisonType"/> is <see cref="StringComparison.Ordinal"/>.
+    /// </summary>
+    /// <remarks>
+    /// The default exception thrown is an <see cref="ArgumentException"/>.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref readonly Validatable<TValue> IfNotContains<TValue>(this in Validatable<TValue> validatable, Func<TValue, string> func, string otherString, StringComparison comparisonType = StringComparison.Ordinal, [CallerArgumentExpression("func")] string? funcName = null)
+        where TValue : notnull
+    {
+        Validator.ThrowIfNotContains(func(validatable.Value), $"{validatable.ParamName}: {funcName}", validatable.ExceptionCustomizations, otherString, comparisonType);
+
+        return ref validatable;
+    }
 }

--- a/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
+++ b/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
@@ -216,4 +216,34 @@ public static partial class ValidatableExtensions
 
         return ref validatable;
     }
+
+    /// <summary>
+    /// Throws an exception if the string contains the given <paramref name="otherString"/>
+    /// Default <paramref name="comparisonType"/> is Ordinal.
+    /// </summary>
+    /// <remarks>
+    /// The default exception thrown is an <see cref="ArgumentException"/>.
+    /// </remarks>
+    public static ref readonly Validatable<string> IfContains(this in Validatable<string> validatable, string otherString, StringComparison comparisonType = StringComparison.Ordinal)
+    {
+        Validator.ThrowIfContains(validatable.Value, validatable.ParamName, validatable.ExceptionCustomizations, otherString, comparisonType);
+
+        return ref validatable;
+    }
+    
+    /// <summary>
+    /// Throws an exception if the string does not contain the given <paramref name="otherString"/>.
+    /// Default <paramref name="comparisonType"/> is Ordinal.
+    /// </summary>
+    /// <remarks>
+    /// The default exception thrown is an <see cref="ArgumentException"/>.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ref readonly Validatable<string> IfNotContains(this in Validatable<string> validatable, string otherString, StringComparison comparisonType = StringComparison.Ordinal)
+    {
+        Validator.ThrowIfNotContains(validatable.Value, validatable.ParamName, validatable.ExceptionCustomizations, otherString, comparisonType);
+
+        return ref validatable;
+    }
+
 }

--- a/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
+++ b/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
@@ -219,7 +219,7 @@ public static partial class ValidatableExtensions
 
     /// <summary>
     /// Throws an exception if the string contains the given <paramref name="otherString"/>
-    /// Default <paramref name="comparisonType"/> is Ordinal.
+    /// Default <paramref name="comparisonType"/> is <see cref="StringComparison.Ordinal"/>..
     /// </summary>
     /// <remarks>
     /// The default exception thrown is an <see cref="ArgumentException"/>.
@@ -233,7 +233,7 @@ public static partial class ValidatableExtensions
     
     /// <summary>
     /// Throws an exception if the string does not contain the given <paramref name="otherString"/>.
-    /// Default <paramref name="comparisonType"/> is Ordinal.
+    /// Default <paramref name="comparisonType"/> is <see cref="StringComparison.Ordinal"/>.
     /// </summary>
     /// <remarks>
     /// The default exception thrown is an <see cref="ArgumentException"/>.

--- a/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
+++ b/src/ValidatableExtensions/ValidatableExtensions.Strings.cs
@@ -218,12 +218,13 @@ public static partial class ValidatableExtensions
     }
 
     /// <summary>
-    /// Throws an exception if the string contains the given <paramref name="otherString"/>
-    /// Default <paramref name="comparisonType"/> is <see cref="StringComparison.Ordinal"/>..
+    /// Throws an exception if the string contains the given <paramref name="otherString"/>.
+    /// Default <paramref name="comparisonType"/> is <see cref="StringComparison.Ordinal"/>.
     /// </summary>
     /// <remarks>
     /// The default exception thrown is an <see cref="ArgumentException"/>.
     /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ref readonly Validatable<string> IfContains(this in Validatable<string> validatable, string otherString, StringComparison comparisonType = StringComparison.Ordinal)
     {
         Validator.ThrowIfContains(validatable.Value, validatable.ParamName, validatable.ExceptionCustomizations, otherString, comparisonType);

--- a/src/Validators/Validator.Strings.cs
+++ b/src/Validators/Validator.Strings.cs
@@ -136,4 +136,22 @@ internal static partial class Validator
             ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should start with '{str}'.");
         }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfContains(string value, string paramName, ExceptionCustomizations? exceptionCustomizations, string otherString, StringComparison comparisonType)
+    {
+        if (value.Contains(otherString, comparisonType))
+        {
+            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should not contain '{otherString}'. (Comparison Type: {comparisonType})");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfNotContains(string value, string paramName, ExceptionCustomizations? exceptionCustomizations, string otherString, StringComparison comparisonType)
+    {
+        if (!value.Contains(otherString, StringComparison.Ordinal))
+        {
+            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should contain '{otherString}'. (Comparison Type: {comparisonType})");
+        }
+    }
 }

--- a/src/Validators/Validator.Strings.cs
+++ b/src/Validators/Validator.Strings.cs
@@ -142,16 +142,16 @@ internal static partial class Validator
     {
         if (value.Contains(otherString, comparisonType))
         {
-            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should not contain '{otherString}'. (Comparison Type: {comparisonType})");
+            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should not contain '{otherString}' (Comparison Type: {comparisonType}).");
         }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void ThrowIfNotContains(string value, string paramName, ExceptionCustomizations? exceptionCustomizations, string otherString, StringComparison comparisonType)
     {
-        if (!value.Contains(otherString, StringComparison.Ordinal))
+        if (!value.Contains(otherString, comparisonType))
         {
-            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should contain '{otherString}'. (Comparison Type: {comparisonType})");
+            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should contain '{otherString}' (Comparison Type: {comparisonType}).");
         }
     }
 }

--- a/src/Validators/Validator.Strings.cs
+++ b/src/Validators/Validator.Strings.cs
@@ -142,7 +142,7 @@ internal static partial class Validator
     {
         if (value.Contains(otherString, comparisonType))
         {
-            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should not contain '{otherString}' (Comparison Type: {comparisonType}).");
+            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should not contain '{otherString}' (comparison type: '{comparisonType}').");
         }
     }
 
@@ -151,7 +151,7 @@ internal static partial class Validator
     {
         if (!value.Contains(otherString, comparisonType))
         {
-            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should contain '{otherString}' (Comparison Type: {comparisonType}).");
+            ExceptionThrower.Throw(paramName, exceptionCustomizations, $"String should contain '{otherString}' (comparison type: '{comparisonType}').");
         }
     }
 }

--- a/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringPropertiesTests.cs
+++ b/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringPropertiesTests.cs
@@ -567,7 +567,7 @@ public class StringPropertiesTests
 
         // Assert
         action.Should().ThrowExactly<ArgumentException>()
-            .WithMessage($"String should not contain 'oh' (Comparison Type: Ordinal). (Parameter '{nameof(person)}: p => p.Name')");
+            .WithMessage($"String should not contain 'oh' (comparison Type: '{StringComparison.Ordinal}'). (Parameter '{nameof(person)}: p => p.Name')");
     }
 
     [TestMethod]
@@ -594,7 +594,7 @@ public class StringPropertiesTests
 
         // Assert
         action.Should().ThrowExactly<ArgumentException>()
-            .WithMessage($"String should contain 'Oh' (Comparison Type: Ordinal). (Parameter '{nameof(person)}: p => p.Name')");
+            .WithMessage($"String should contain 'Oh' (comparison type: '{StringComparison.Ordinal}'). (Parameter '{nameof(person)}: p => p.Name')");
     }
 
     [TestMethod]
@@ -610,55 +610,69 @@ public class StringPropertiesTests
         action.Should().NotThrow();
     }
 
-    [TestMethod]
-    public void ThrowIfPropertyContains_UsingOrdinalIgnoreCase_WhenPropertyContains_ShouldThrow()
+    [DataTestMethod]
+    [DataRow("value", "AL", StringComparison.OrdinalIgnoreCase)]
+    [DataRow("\u0068\u0065\u006c\u006c\u006f", "\u0065", StringComparison.InvariantCulture)]
+    [DataRow("\u0068\u0065\u006c\u006c\u006f", "\u0045", StringComparison.InvariantCultureIgnoreCase)]
+    public void ThrowIfPropertyContains_WhenPropertyContainsUsingCustomComparisonType_ShouldThrow(string value, string otherValue, StringComparison comparisonType)
     {
         // Arrange
-        var person = new { Name = "John" };
+        var person = new { Name = value };
 
         // Act
-        Action action = () => person.Throw().IfContains(p => p.Name, "Oh", StringComparison.OrdinalIgnoreCase);
+        Action action = () => person.Throw().IfContains(p => p.Name, otherValue, comparisonType);
 
         // Assert
-        action.Should().ThrowExactly<ArgumentException>()
-            .WithMessage($"String should not contain 'Oh' (Comparison Type: OrdinalIgnoreCase). (Parameter '{nameof(person)}: p => p.Name')");
+        action.Should()
+            .ThrowExactly<ArgumentException>()
+            .WithMessage($"String should not contain '{otherValue}' (comparison type: '{comparisonType}'). (Parameter '{nameof(person)}: p => p.Name')");
     }
 
-    [TestMethod]
-    public void ThrowIfPropertyContains_UsingOrdinalIgnoreCase_WhenPropertyNotContains_ShouldNotThrow()
+    [DataTestMethod]
+    [DataRow("value", "123", StringComparison.OrdinalIgnoreCase)]
+    [DataRow("\u0041\u0041", "\u0031", StringComparison.InvariantCulture)]
+    [DataRow("AA", "\u0031", StringComparison.InvariantCultureIgnoreCase)]
+    public void ThrowIfPropertyContains_WhenPropertyNotContainsUsingCustomComparisonType_ShouldNotThrow(string value, string otherValue, StringComparison comparisonType)
     {
         // Arrange
-        var person = new { Name = "John" };
+        var person = new { Name = value };
 
         // Act
-        Action action = () => person.Throw().IfContains(p => p.Name, "123", StringComparison.OrdinalIgnoreCase);
+        Action action = () => person.Throw().IfContains(p => p.Name, otherValue, comparisonType);
 
         // Assert
         action.Should().NotThrow();
     }
-
-    [TestMethod]
-    public void ThrowIfPropertyNotContains_UsingOrdinalIgnoreCase_WhenPropertyNotContains_ShouldThrow()
+    
+    [DataTestMethod]
+    [DataRow("value", "123", StringComparison.OrdinalIgnoreCase)]
+    [DataRow("\u0041\u0041", "\u0031", StringComparison.InvariantCulture)]
+    [DataRow("AA", "\u0031", StringComparison.InvariantCultureIgnoreCase)]
+    public void ThrowIfPropertyNotContains_WhenPropertyNotContainsUsingCustomComparisonType_ShouldThrow(string value, string otherValue, StringComparison comparisonType)
     {
         // Arrange
-        var person = new { Name = "John" };
+        var person = new { Name = value };
 
         // Act
-        Action action = () => person.Throw().IfNotContains(p => p.Name, "123", StringComparison.OrdinalIgnoreCase);
+        Action action = () => person.Throw().IfNotContains(p => p.Name, otherValue, comparisonType);
 
         // Assert
-        action.Should().ThrowExactly<ArgumentException>()
-            .WithMessage($"String should contain '123' (Comparison Type: OrdinalIgnoreCase). (Parameter '{nameof(person)}: p => p.Name')");
+        action.Should()
+            .ThrowExactly<ArgumentException>()
+            .WithMessage($"String should contain '{otherValue}' (comparison type: '{comparisonType}'). (Parameter '{nameof(person)}: p => p.Name')");
     }
 
-    [TestMethod]
-    public void ThrowIfPropertyNotContains_UsingOrdinalIgnoreCase_WhenPropertyContains_ShouldNotThrow()
+    [DataTestMethod]
+    [DataRow("value", "AL", StringComparison.OrdinalIgnoreCase)]
+    [DataRow("\u0068\u0065\u006c\u006c\u006f", "\u0065", StringComparison.InvariantCulture)]
+    [DataRow("\u0068\u0065\u006c\u006c\u006f", "\u0045", StringComparison.InvariantCultureIgnoreCase)]
+    public void ThrowIfPropertyNotContains_WhenPropertyContainsUsingCustomComparisonType_ShouldNotThrow(string value, string otherValue, StringComparison comparisonType)
     {
         // Arrange
-        var person = new { Name = "John" };
+        var person = new { Name = value };
 
         // Act
-        Action action = () => person.Throw().IfNotContains(p => p.Name, "Oh", StringComparison.OrdinalIgnoreCase);
+        Action action = () => person.Throw().IfNotContains(p => p.Name, otherValue, comparisonType);
 
         // Assert
         action.Should().NotThrow();

--- a/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringPropertiesTests.cs
+++ b/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringPropertiesTests.cs
@@ -555,4 +555,112 @@ public class StringPropertiesTests
         // Assert
         action.Should().NotThrow();
     }
+
+    [TestMethod]
+    public void ThrowIfPropertyContains_WhenPropertyContains_ShouldThrow()
+    {
+        // Arrange
+        var person = new { Name = "John" };
+
+        // Act
+        Action action = () => person.Throw().IfContains(p => p.Name, "oh");
+
+        // Assert
+        action.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"String should not contain 'oh' (Comparison Type: Ordinal). (Parameter '{nameof(person)}: p => p.Name')");
+    }
+
+    [TestMethod]
+    public void ThrowIfPropertyContains_WhenPropertyNotContains_ShouldNotThrow()
+    {
+        // Arrange
+        var person = new { Name = "John" };
+
+        // Act
+        Action action = () => person.Throw().IfContains(p => p.Name, "Oh");
+
+        // Assert
+        action.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void ThrowIfPropertyNotContains_WhenPropertyNotContains_ShouldThrow()
+    {
+        // Arrange
+        var person = new { Name = "John" };
+
+        // Act
+        Action action = () => person.Throw().IfNotContains(p => p.Name, "Oh");
+
+        // Assert
+        action.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"String should contain 'Oh' (Comparison Type: Ordinal). (Parameter '{nameof(person)}: p => p.Name')");
+    }
+
+    [TestMethod]
+    public void ThrowIfPropertyNotContains_WhenPropertyContains_ShouldNotThrow()
+    {
+        // Arrange
+        var person = new { Name = "John" };
+
+        // Act
+        Action action = () => person.Throw().IfNotContains(p => p.Name, "oh");
+
+        // Assert
+        action.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void ThrowIfPropertyContains_UsingOrdinalIgnoreCase_WhenPropertyContains_ShouldThrow()
+    {
+        // Arrange
+        var person = new { Name = "John" };
+
+        // Act
+        Action action = () => person.Throw().IfContains(p => p.Name, "Oh", StringComparison.OrdinalIgnoreCase);
+
+        // Assert
+        action.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"String should not contain 'Oh' (Comparison Type: OrdinalIgnoreCase). (Parameter '{nameof(person)}: p => p.Name')");
+    }
+
+    [TestMethod]
+    public void ThrowIfPropertyContains_UsingOrdinalIgnoreCase_WhenPropertyNotContains_ShouldNotThrow()
+    {
+        // Arrange
+        var person = new { Name = "John" };
+
+        // Act
+        Action action = () => person.Throw().IfContains(p => p.Name, "123", StringComparison.OrdinalIgnoreCase);
+
+        // Assert
+        action.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void ThrowIfPropertyNotContains_UsingOrdinalIgnoreCase_WhenPropertyNotContains_ShouldThrow()
+    {
+        // Arrange
+        var person = new { Name = "John" };
+
+        // Act
+        Action action = () => person.Throw().IfNotContains(p => p.Name, "123", StringComparison.OrdinalIgnoreCase);
+
+        // Assert
+        action.Should().ThrowExactly<ArgumentException>()
+            .WithMessage($"String should contain '123' (Comparison Type: OrdinalIgnoreCase). (Parameter '{nameof(person)}: p => p.Name')");
+    }
+
+    [TestMethod]
+    public void ThrowIfPropertyNotContains_UsingOrdinalIgnoreCase_WhenPropertyContains_ShouldNotThrow()
+    {
+        // Arrange
+        var person = new { Name = "John" };
+
+        // Act
+        Action action = () => person.Throw().IfNotContains(p => p.Name, "Oh", StringComparison.OrdinalIgnoreCase);
+
+        // Assert
+        action.Should().NotThrow();
+    }
 }

--- a/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
+++ b/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
@@ -450,4 +450,64 @@ public class StringsTests
         // Assert
         action.Should().NotThrow();
     }
+
+    [TestMethod]
+    public void ThrowIfContains_WhenContains_ShouldThrow()
+    {
+        // Arrange
+        string value = "the quick brown fox jumps over the lazy dog.";
+        string otherString = "quick";
+
+        // Act
+        Action action = () => value.Throw().IfContains(otherString);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentException>()
+            .WithMessage($"String should not contain 'quick'. (Comparison Type: Ordinal) (Parameter '{nameof(value)}')");
+    }
+
+    [TestMethod]
+    public void ThrowIfContains_WhenNotContains_ShouldNotThrow()
+    {
+        // Arrange
+        string value = "the quick brown fox jumps over the lazy dog.";
+        string otherString = "horse";
+
+        // Act
+        Action action = () => value.Throw().IfContains(otherString);
+
+        // Assert
+        action.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void ThrowIfNotContains_WhenNotContains_ShouldThrow()
+    {
+        // Arrange
+        string value = "the quick brown fox jumps over the lazy dog.";
+        string otherValue = "horse";
+
+        // Act
+        Action action = () => value.Throw().IfNotContains(otherValue);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentException>()
+            .WithMessage($"String should contain 'horse'. (Comparison Type: Ordinal) (Parameter '{nameof(value)}')");
+    }
+
+    [TestMethod]
+    public void ThrowIfNotContains_WhenContains_ShouldNotThrow()
+    {
+        // Arrange
+        string value = "the quick brown fox jumps over the lazy dog.";
+        string otherValue = "jumps";
+
+        // Act
+        Action action = () => value.Throw().IfNotContains(otherValue);
+
+        // Assert
+        action.Should().NotThrow();
+    }
 }

--- a/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
+++ b/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
@@ -464,7 +464,7 @@ public class StringsTests
         // Assert
         action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"String should not contain '{otherValue}' (Comparison Type: Ordinal). (Parameter '{nameof(value)}')");
+            .WithMessage($"String should not contain '{otherValue}' (comparison type: '{StringComparison.Ordinal}'). (Parameter '{nameof(value)}')");
     }
 
     [TestMethod]
@@ -494,7 +494,7 @@ public class StringsTests
         // Assert
         action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"String should contain '{otherValue}' (Comparison Type: Ordinal). (Parameter '{nameof(value)}')");
+            .WithMessage($"String should contain '{otherValue}' (comparison type: '{StringComparison.Ordinal}'). (Parameter '{nameof(value)}')");
     }
 
     [TestMethod]
@@ -510,64 +510,60 @@ public class StringsTests
         // Assert
         action.Should().NotThrow();
     }
-
-    [TestMethod]
-    public void ThrowIfContains_UsingOrdinalIgnoreCase_WhenContains_ShouldThrow()
+    
+    [DataTestMethod]
+    [DataRow("value", "AL", StringComparison.OrdinalIgnoreCase)]
+    [DataRow("\u0068\u0065\u006c\u006c\u006f", "\u0065\u006c", StringComparison.InvariantCulture)]
+    [DataRow("\u0041\u0041", "\u0061", StringComparison.InvariantCultureIgnoreCase)]
+    public void ThrowIfContains_WhenContainsUsingCustomComparisonType_ShouldThrow(string value, string otherValue, StringComparison comparisonType)
     {
-        // Arrange
-        string value = "the quick brown fox jumps over the lazy dog.";
-        string otherValue = "Quick";
-
         // Act
-        Action action = () => value.Throw().IfContains(otherValue, StringComparison.OrdinalIgnoreCase);
+        Action action = () => value.Throw().IfContains(otherValue, comparisonType);
 
         // Assert
         action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"String should not contain '{otherValue}' (Comparison Type: OrdinalIgnoreCase). (Parameter '{nameof(value)}')");
+            .WithMessage($"String should not contain '{otherValue}' (comparison type: '{comparisonType}'). (Parameter '{nameof(value)}')");
     }
 
-    [TestMethod]
-    public void ThrowIfContains_UsingOrdinalIgnoreCase_WhenNotContains_ShouldNotThrow()
+    [DataTestMethod]
+    [DataRow("value", "different value", StringComparison.OrdinalIgnoreCase)]
+    [DataRow("\u0061\u030a", "different value", StringComparison.InvariantCulture)]
+    [DataRow("AA", "different value", StringComparison.InvariantCultureIgnoreCase)]
+    public void ThrowIfContains_WhenNotContainsUsingCustomComparisonType_ShouldNotThrow(string value, string otherValue, StringComparison comparisonType)
     {
-        // Arrange
-        string value = "the quick brown fox jumps over the lazy dog.";
-        string otherValue = "horse";
-
         // Act
-        Action action = () => value.Throw().IfContains(otherValue, StringComparison.OrdinalIgnoreCase);
+        Action action = () => value.Throw().IfContains(otherValue, comparisonType);
 
         // Assert
         action.Should().NotThrow();
     }
 
-    [TestMethod]
-    public void ThrowIfNotContains_UsingOrdinalIgnoreCase_WhenNotContains_ShouldThrow()
+    [DataTestMethod]
+    [DataRow("value", "different value", StringComparison.OrdinalIgnoreCase)]
+    [DataRow("\u0061\u030a", "different value", StringComparison.InvariantCulture)]
+    [DataRow("AA", "different value", StringComparison.InvariantCultureIgnoreCase)]
+    public void ThrowIfNotContains_WhenNotContainsUsingCustomComparisonType_ShouldThrow(string value, string otherValue, StringComparison comparisonType)
     {
-        // Arrange
-        string value = "the quick brown fox jumps over the lazy dog.";
-        string otherValue = "Horse";
-
         // Act
-        Action action = () => value.Throw().IfNotContains(otherValue, StringComparison.OrdinalIgnoreCase);
+        Action action = () => value.Throw().IfNotContains(otherValue, comparisonType);
 
         // Assert
         action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"String should contain '{otherValue}' (Comparison Type: OrdinalIgnoreCase). (Parameter '{nameof(value)}')");
+            .WithMessage($"String should contain '{otherValue}' (comparison type: '{comparisonType}'). (Parameter '{nameof(value)}')");
     }
 
-    [TestMethod]
-    public void ThrowIfNotContains_UsingOrdinalIgnoreCase_WhenContains_ShouldNotThrow()
+    [DataTestMethod]
+    [DataRow("value", "AL", StringComparison.OrdinalIgnoreCase)]
+    [DataRow("\u0068\u0065\u006c\u006c\u006f", "\u0065\u006c", StringComparison.InvariantCulture)]
+    [DataRow("\u0041\u0041", "\u0061", StringComparison.InvariantCultureIgnoreCase)]
+    public void ThrowIfNotContains_WhenContainsUsingCustomComparisonType_ShouldNotThrow(string value, string otherValue, StringComparison comparisonType)
     {
-        // Arrange
-        string value = "the quick brown fox jumps over the lazy dog.";
-        string otherValue = "Jumps";
-
         // Act
-        Action action = () => value.Throw().IfNotContains(otherValue, StringComparison.OrdinalIgnoreCase);
+        Action action = () => value.Throw().IfNotContains(otherValue, comparisonType);
 
         // Assert
         action.Should().NotThrow();
-    }   
+    }
 }

--- a/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
+++ b/tests/UnitTests/ValidatableExtensions/ValidatableExtensions.StringsTests.cs
@@ -456,15 +456,15 @@ public class StringsTests
     {
         // Arrange
         string value = "the quick brown fox jumps over the lazy dog.";
-        string otherString = "quick";
+        string otherValue = "quick";
 
         // Act
-        Action action = () => value.Throw().IfContains(otherString);
+        Action action = () => value.Throw().IfContains(otherValue);
 
         // Assert
         action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"String should not contain 'quick'. (Comparison Type: Ordinal) (Parameter '{nameof(value)}')");
+            .WithMessage($"String should not contain '{otherValue}' (Comparison Type: Ordinal). (Parameter '{nameof(value)}')");
     }
 
     [TestMethod]
@@ -472,10 +472,10 @@ public class StringsTests
     {
         // Arrange
         string value = "the quick brown fox jumps over the lazy dog.";
-        string otherString = "horse";
+        string otherValue = "horse";
 
         // Act
-        Action action = () => value.Throw().IfContains(otherString);
+        Action action = () => value.Throw().IfContains(otherValue);
 
         // Assert
         action.Should().NotThrow();
@@ -494,7 +494,7 @@ public class StringsTests
         // Assert
         action.Should()
             .ThrowExactly<ArgumentException>()
-            .WithMessage($"String should contain 'horse'. (Comparison Type: Ordinal) (Parameter '{nameof(value)}')");
+            .WithMessage($"String should contain '{otherValue}' (Comparison Type: Ordinal). (Parameter '{nameof(value)}')");
     }
 
     [TestMethod]
@@ -510,4 +510,64 @@ public class StringsTests
         // Assert
         action.Should().NotThrow();
     }
+
+    [TestMethod]
+    public void ThrowIfContains_UsingOrdinalIgnoreCase_WhenContains_ShouldThrow()
+    {
+        // Arrange
+        string value = "the quick brown fox jumps over the lazy dog.";
+        string otherValue = "Quick";
+
+        // Act
+        Action action = () => value.Throw().IfContains(otherValue, StringComparison.OrdinalIgnoreCase);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentException>()
+            .WithMessage($"String should not contain '{otherValue}' (Comparison Type: OrdinalIgnoreCase). (Parameter '{nameof(value)}')");
+    }
+
+    [TestMethod]
+    public void ThrowIfContains_UsingOrdinalIgnoreCase_WhenNotContains_ShouldNotThrow()
+    {
+        // Arrange
+        string value = "the quick brown fox jumps over the lazy dog.";
+        string otherValue = "horse";
+
+        // Act
+        Action action = () => value.Throw().IfContains(otherValue, StringComparison.OrdinalIgnoreCase);
+
+        // Assert
+        action.Should().NotThrow();
+    }
+
+    [TestMethod]
+    public void ThrowIfNotContains_UsingOrdinalIgnoreCase_WhenNotContains_ShouldThrow()
+    {
+        // Arrange
+        string value = "the quick brown fox jumps over the lazy dog.";
+        string otherValue = "Horse";
+
+        // Act
+        Action action = () => value.Throw().IfNotContains(otherValue, StringComparison.OrdinalIgnoreCase);
+
+        // Assert
+        action.Should()
+            .ThrowExactly<ArgumentException>()
+            .WithMessage($"String should contain '{otherValue}' (Comparison Type: OrdinalIgnoreCase). (Parameter '{nameof(value)}')");
+    }
+
+    [TestMethod]
+    public void ThrowIfNotContains_UsingOrdinalIgnoreCase_WhenContains_ShouldNotThrow()
+    {
+        // Arrange
+        string value = "the quick brown fox jumps over the lazy dog.";
+        string otherValue = "Jumps";
+
+        // Act
+        Action action = () => value.Throw().IfNotContains(otherValue, StringComparison.OrdinalIgnoreCase);
+
+        // Assert
+        action.Should().NotThrow();
+    }   
 }


### PR DESCRIPTION
resolves #23 

I've added extension methods and also added the option to pass `StringComparison` Enum value to the methods, by default it is set to `StringComparison.Ordinal` but the user can change it by passing their own values if required. 

I've also included test cases for these conditions. 
